### PR TITLE
Updates Plugin & Adds Support For When Product Attributes Aren't Used…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,44 +1,61 @@
 === Woo Attributes Coupon ===
 Contributors: gauravnagpal
-Tags: Attributes, coupons, discounts, sales, WooCommerce
+Tags: WooCommerce, Attributes, Coupons, Discounts, Sales, Product Tags
 Requires at least: 3.x
-Tested up to: 4.6.1
-Stable tag: 1.0.0
+Tested up to: 5.1.1
+Stable tag: 2.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=nagpal.gaurav89@gmail.com
+Donate link: https://www.paypal.me/gauravnagpal
 
-Woocommerce coupon section extension for adding coupon for special attributes.
+Woocommerce coupon section extension for adding coupon for special attributes and tags. Also, you can categorized the coupons.
 
 == Description ==
-Less sold products with special attributes can be sold easily using this method without effecting sale for popular products. Woocommerce coupon section extention for adding coupon for special attributes. 
-After enabling this plugin you will see new multiple select box in coupon \"user restriction\" section. All the other preferences will not be effected, it will work perfectly as it was before.
+Less sold products with special attributes and tags can be sold easily using this feature without effecting sale for popular products. Woocommerce coupon section extention for adding coupon for special attributes and tags. 
+After enabling this plugin you will see new multiple select box in coupon "user restriction" section. All the other preferences will not be effected, it will work perfectly as it was before.
+
+* Work for both attributes and tags
+* Coupon categories
+* No new section for coupons
+* All other existing features will remain same
+* Can be club with other woocommerce coupon rules
+* Can be applied percentage or flat amount on products
+* Supported variable and simple product types 
+* Attribute created in "Products > Attributes" tab are supported
+
+If you like this easy plugin and if plugin is improving your sales then <a href="https://www.paypal.me/gauravnagpal">Donate</a> a little to this development time or at least spend couple of minutes for feedback.
+
+Special Thanks to Jason Robinson.
 
 == Installation ==
 = Using The WordPress Dashboard =
 
-1. Navigate to the \'Add New\' in the plugins dashboard
-2. Search for \'woo-attributes-coupon\'
-3. Click \'Install Now\'
+1. Navigate to the 'Add New' in the plugins dashboard
+2. Search for 'woo-attributes-coupon'
+3. Click 'Install Now'
 4. Activate the plugin on the Plugin dashboard
 
 = Uploading in WordPress Dashboard =
 
-1. Navigate to the \'Add New\' in the plugins dashboard
-2. Navigate to the \'Upload\' area
+1. Navigate to the 'Add New' in the plugins dashboard
+2. Navigate to the 'Upload' area
 3. Select `woo-attributes-coupon.zip` from your computer
-4. Click \'Install Now\'
+4. Click 'Install Now'
 5. Activate the plugin in the Plugin dashboard
 
 = Using FTP =
 
 1. Download `woo-attributes-coupon.zip`
 2. Extract the `woo-attributes-coupon` directory to your computer
-3. Upload the `woo-attributes-coupon` directory to the `/wp-content/plugins/` directory
+3. Upload the `woo-attributes-coupon` directory to the `wp-content/plugins` directory
 4. Activate the plugin in the Plugin dashboard
 
 
 == Frequently Asked Questions ==
+= Can we apply same coupon to multiple attributes=
+
+Yes you can! Multiple select box type is used for selecting attributes, so you can assign as many attributes as you want with single coupon
+
 = Where can I report bugs or contribute to the project? =
 
 Bugs can be reported preferably on the [Woo Attributes Coupon GitHub repository](https://github.com/gnagpal22/woo-attributes-coupon/issues).
@@ -52,8 +69,25 @@ Yes you can! Join in on our [GitHub repository](https://github.com/gnagpal22/woo
 1. Admin side new option in coupon code section
 
 == Changelog ==
+
+= 2.2.0 =
+* Updated code coupon categories
+* Tested with latest wordpress version 5.1.1
+* Tested with latest Woocommerce version 3.6.2
+
+= 2.1.0 =
+* Tested with latest wordpress version 5.0.3
+* Tested with latest Woocommerce version 3.5.4
+* Updated code for fetching product & instance ID
+
+= 2.0.0 =
+* coupons based on product tags
+* product tags in selection in admin coupon section
+* Variable type product support
+* Bug Fixes
+
 = 1.0.0 =
 * initial version
 
 == Upgrade Notice ==
-This is initial plugin so need to worry about anything. Everything else will work perfectly.
+New coupon category feature added in plugin so no need to worry about anything. Everything else will work perfectly fine. 

--- a/woo-attributes-coupon.php
+++ b/woo-attributes-coupon.php
@@ -2,18 +2,20 @@
 /**
  * Woo Attributes Coupon
  *
- * Woocommerce coupon section extension for adding coupon for special attributes.
+ * Woocommerce coupon section extension for adding coupon for special attributes and tags. Also, you can categorized the coupons.
  *
  * Plugin Name: 	  Woo Attributes Coupon
  * Plugin URI:  	  https://github.com/gnagpal22/woo-attributes-coupon
- * Description: 	  Woocommerce coupon section extension for adding coupon for special attributes.
- * Version:     	  1.0
+ * Description: 	  Woocommerce coupon section extension for adding coupon for special attributes and tags. Also, you can categorized the coupons.
+ * Version:     	  2.2.0
  * Author:      	  Gaurav Nagpal
  * Author URI:  	  http://www.gauravnagpal.com/
  * Text Domain: 	  woo-attributes-coupon
  * License:     	  GPL-2.0+
  * License URI:           http://www.gnu.org/licenses/gpl-2.0.txt
  * Domain Path: 	  /languages
+ * 
+ * WC tested up to:   3.6.2
  * 
  * @package   Woo_Attributes_Coupon
  * @author    Gaurav Nagpal <nagpal.gaurav89@gmail.com>
@@ -70,5 +72,37 @@ if ( in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', g
 		add_action( 'plugins_loaded', array( 'Woo_Attributes_Coupon_Admin', 'get_instance' ) );
 
 	}
-
+	
+	
+	// Create Taxonomy for custom Coupon Category
+	add_action( 'init', 'create_topics_hierarchical_taxonomy', 0 );
+	function create_topics_hierarchical_taxonomy() {
+	  $labels = array(
+		'name' => _x( 'Coupon Category', 'taxonomy general name' ),
+		'singular_name' => _x( 'Category', 'taxonomy singular name' ),
+		'search_items' =>  __( 'Search Categories' ),
+		'all_items' => __( 'All Categories' ),
+		'parent_item' => __( 'Parent Category' ),
+		'parent_item_colon' => __( 'Parent Category:' ),
+		'edit_item' => __( 'Edit Category' ), 
+		'update_item' => __( 'Update Category' ),
+		'add_new_item' => __( 'Add New Category' ),
+		'new_item_name' => __( 'New Category Name' ),
+		'menu_name' => __( 'Coupon Categories' ),
+	  );    
+	 
+	// Now register the taxonomy 
+	  register_taxonomy('coupon_categories',array('shop_coupon'), array(
+		'hierarchical' => true,
+		'labels' => $labels,
+		'show_ui' => true,
+		'show_admin_column' => true,
+		'query_var' => true,
+		'rewrite' => array( 'slug' => 'coupon_categories' ),
+	  ));
+	 
+	}
+	
 }
+
+


### PR DESCRIPTION
This plugin has been updated to fix this bug/feature:
https://wordpress.org/support/topic/does-not-apply-if-product-attribute-is-not-used-in-variation/

It now allows WooCommerce to accept discount on product attributes that aren't used for variant products.

It also has updates from WordPress' plugin directory, which aren't present in Git.